### PR TITLE
商品購入確認ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_item-buy.scss
+++ b/app/assets/stylesheets/_item-buy.scss
@@ -1,0 +1,122 @@
+.buy-wrapper{
+  display: block;
+  .buy-header-logo{
+    height: 130px;
+    text-align: center;
+    .header-icon{
+      margin: 40px 0;
+      width: 150px;
+      height: 50px;
+    }
+  }
+  .main-content{
+    display: block;
+    .buy-header{
+      width: 700px;
+      margin: 0 auto;
+      background: #fff;
+      text-align: center;
+      .buy-header-box{
+        border-bottom: 1px solid #f5f5f5;
+        h3{
+          display: inline-block;
+          font-size: 25px;
+          font-weight: bold;
+          margin: 30px;
+        }
+      }
+      .buy-content{
+        border-bottom: 1px solid #f5f5f5;
+        padding-bottom: 48px;
+        &__inner{
+          margin-top: 30px;
+          .buy-item-box{
+            display: flex;
+            max-width: 400px;
+            margin: 0 auto;
+            &__image{
+              display: inline-block;
+              height: 100px;
+              width: 100px;
+            }
+            &__detail{
+              padding-left: 10px;
+              text-align:left;
+              display: inline-block;
+              &__name{
+                
+              }
+              &__price{
+                font-weight: bold;
+              }
+            }
+            
+          }
+          .price-table{
+            margin: auto;
+            width: 300px;
+            .price-cell-box{
+              height: 100px;
+              line-height: 100px;
+              border-bottom: 1px solid #f5f5f5;
+              margin: 30px;
+              .price-cell-label{
+                font-weight: bold;
+                float: left;
+              }
+              .price-cell{
+                font-size: 1.3rem;
+                float: right;
+                font-weight: bold;
+              }
+            }
+          }
+          .information-table{
+            font-size: 0.9rem;
+            width: 300px;
+            margin: auto;
+            .information-cell-box{
+              border-bottom: 1px solid #f5f5f5;
+              margin: 30px;
+              text-align: left;
+              padding-bottom: 30px;
+              .information-cell-label{
+                font-weight: bold;
+
+              }
+              .information-cell{
+
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+.signup-footer{
+  width: 456px;
+  height: 220px;
+  margin: 0 auto;
+  padding: 40px 0;
+  text-align: center;
+  nav{
+    ul{
+      justify-content: center;
+      display: flex;
+      li{
+        margin: 5px;
+        a{
+          font-size: 12px;
+          color: gray;
+          text-decoration: none;
+        }
+      }
+    }
+  }
+  &__logo{
+    display: block;
+    margin-top: 30px;
+  }
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,5 +28,6 @@
 @import "./identification";
 @import "./breadcrumb";
 @import "./payjp-button";
+@import "./item-buy";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -1,0 +1,7 @@
+class TransactionController < ApplicationController
+
+  def buy
+    @item = Item.find(params[:id])
+  end
+
+end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -57,7 +57,7 @@
         = link_to '編集', edit_item_path, method: :get
         = link_to '削除', item_path, method: :delete
       - else
-        = link_to '購入画面に進む', "/transaction/buy/#{@item.id}"
+        = link_to '購入画面に進む', buy_transaction_index_path(@item)
   .itme_explanation_wrapper
     .item_explanation #{@item.detail}
   .item_butan_wrapper

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -57,8 +57,7 @@
         = link_to '編集', edit_item_path, method: :get
         = link_to '削除', item_path, method: :delete
       - else
-        = form_tag(action: :pay, method: :post) do
-          %script.payjp-button{src: "https://checkout.pay.jp", type: "text/javascript" ,"data-text": "購入画面に進む" ,"data-key": "pk_test_f3748503dd3b3e10e63aa170"}
+        = link_to '購入画面に進む', "/transaction/buy/#{@item.id}"
   .itme_explanation_wrapper
     .item_explanation #{@item.detail}
   .item_butan_wrapper

--- a/app/views/transaction/buy.html.haml
+++ b/app/views/transaction/buy.html.haml
@@ -1,0 +1,55 @@
+.buy-wrapper 
+  .buy-header-logo
+    = link_to image_tag("freemarket_logo_red.svg", class: "header-icon"), root_path
+  .main-content
+    .buy-header
+      .buy-header-box
+        %h3 購入確認
+      .buy-content
+        .buy-content__inner
+          .buy-item-box
+            =image_tag @item.images[0].image.url, class: "buy-item-box__image"
+            .buy-item-box__detail
+              .buy-item-box__detail__name #{@item.name}
+              .buy-item-box__detail__price ￥#{@item.price}円  #{@item.shipping_charge_fee}
+      .buy-content
+        .buy-content__inner 
+          .price-table
+            .price-cell-box
+              %p.price-cell-label 支払い金額
+              %p.price-cell
+                %span ¥#{@item.price}
+          .information-table
+            .information-cell-box
+              %p.information-cell-label 支払い金額
+              %p.information-cell クレジットカード
+              %p.information-cell ************1234
+              %p.information-cell 有効期限 12 / 34
+          .information-table
+            .information-cell-box
+              %p.information-cell-label 配送先
+              %p.information-cell 〒123-4567
+              %p.information-cell 東京都 品川区 １−2−3 111号
+              %p.information-cell マーケット　太郎
+          = form_tag(action: :pay, controller: :items, method: :post) do
+            %script.payjp-button{src: "https://checkout.pay.jp", type: "text/javascript" ,"data-text": "購入画面に進む" ,"data-key": "pk_test_f3748503dd3b3e10e63aa170"}
+                
+%footer.signup-footer
+  %nav
+    %ul.clearfix
+      %li
+        = link_to '#' do
+          プライバシーポリシー
+      %li
+        = link_to '#' do
+          メルカリ利用規約
+      %li
+        = link_to '#' do
+          特定商取引に関する表記
+  = link_to root_path, class: 'signup-footer__logo' do
+    = image_tag 'logo_gray.svg', alt: 'mercari', height: '65', width: '80'
+  %p
+    %small
+      © 2019 Mercari
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,13 +32,16 @@ Rails.application.routes.draw do
   end
   root 'items#index'
 
-  resources :item_detail
-  get "item_detail", to: "item_detail#index"
-
   resources :items,only: [:index,:new,:create,:edit,:update,:show,:destroy]do
     collection do
       post 'pay/:id'=> 'items#pay', as: 'pay'
       get :done
+    end
+  end
+
+  resources :transaction, only: [:index] do
+    collection do
+      get 'buy/:id' => 'transaction#buy'
     end
   end
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
 
   resources :transaction, only: [:index] do
     collection do
-      get 'buy/:id' => 'transaction#buy'
+      get 'buy/:id' => 'transaction#buy', as: 'buy'
     end
   end
   


### PR DESCRIPTION
# what
　購入確認画面ページのhamlmとscssを作成
　それに伴いtranscationコントローラーの作成とページ遷移のためにitem詳細ページのリンクを修正を行った。

# why
　購入前に再度ユーザーに購入商品と支払方法、配送先を確認してもらうため

# 
![localhost_3000_transaction_buy_10](https://user-images.githubusercontent.com/55049751/75599997-98786f00-5aed-11ea-8a0f-d41cc59b11c2.png)
添付画像